### PR TITLE
feat(from-event): observables ready to use from the beginning

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "tonivj5",
+      "name": "Toni Villena",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/7110786?v=4",
+      "profile": "https://github.com/tonivj5",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -109,9 +109,12 @@ export class CounterComponent {
   @ViewChild('reset')
   reset$: Observable<MouseEvent>;
 
-  count$ = merge(this.plus$.pipe(mapTo(1)), this.minus$.pipe(mapTo(-1))).pipe(
+  count$ = merge(
+    this.plus$.pipe(mapTo(1)), 
+    this.minus$.pipe(mapTo(-1))
+  ).pipe(
     startWith(0),
-    scan((count, addition) => count + addition)
+    scan((acc, curr) => acc + curr)
   );
 
   counter$ = this.reset$.pipe(

--- a/README.md
+++ b/README.md
@@ -85,6 +85,42 @@ class HostComponent implements AfterViewInit, OnDestroy {
 }
 ```
 
+You can use it from the beginning, without the need of implement the `AfterViewInit` hook.
+
+```ts
+@Component({
+  template: `
+    <button #plus>+1</button>
+    <button #minus>-1</button>
+    <button #reset>Reset</button>
+    {{ counter$ | async }}
+  `,
+})
+export class CounterComponent {
+  @FromEvent('click')
+  @ViewChild('plus')
+  plus$: Observable<MouseEvent>;
+
+  @FromEvent('click')
+  @ViewChild('minus')
+  minus$: Observable<MouseEvent>;
+
+  @FromEvent('click')
+  @ViewChild('reset')
+  reset$: Observable<MouseEvent>;
+
+  count$ = merge(this.plus$.pipe(mapTo(1)), this.minus$.pipe(mapTo(-1))).pipe(
+    startWith(0),
+    scan((count, addition) => count + addition)
+  );
+
+  counter$ = this.reset$.pipe(
+    startWith(null),
+    switchMap(() => this.count$)
+  );
+}
+```
+
 Have fun, and don't forget to unsubscribe. If you work with **Ivy**, you can do it with [until-destroy](https://github.com/ngneat/until-destroy).
 
 ## Contributors ✨

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <table>
   <tr>
     <td align="center"><a href="https://www.netbasal.com"><img src="https://avatars1.githubusercontent.com/u/6745730?v=4" width="100px;" alt=""/><br /><sub><b>Netanel Basal</b></sub></a><br /><a href="https://github.com/@ngneat/from-event/commits?author=NetanelBasal" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/tonivj5"><img src="https://avatars2.githubusercontent.com/u/7110786?v=4" width="100px;" alt=""/><br /><sub><b>Toni Villena</b></sub></a><br /><a href="https://github.com/@ngneat/from-event/commits?author=tonivj5" title="Code">💻</a> <a href="#example-tonivj5" title="Examples">💡</a></td>
   </tr>
 </table>
 

--- a/projects/ngneat/from-event/src/lib/from-event.spec.ts
+++ b/projects/ngneat/from-event/src/lib/from-event.spec.ts
@@ -1,8 +1,8 @@
-import { AfterViewInit, Component, Input, OnDestroy, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, Input, OnDestroy, ViewChild, OnInit } from '@angular/core';
 import { byText, createComponentFactory, Spectator } from '@ngneat/spectator';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, BehaviorSubject } from 'rxjs';
 import { FromEvent } from '@ngneat/from-event';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntil, take, skip, switchMap } from 'rxjs/operators';
 
 let destroyed = [];
 
@@ -12,19 +12,75 @@ let destroyed = [];
     <button #button>
       <ng-content></ng-content>
     </button>
+
+    <button #buttonConstructor>Constructor {{ id }}</button>
+
+    <button #buttonOnInit>OnInit {{ id }}</button>
   `,
 })
-class ButtonComponent implements AfterViewInit, OnDestroy {
+class ButtonComponent implements OnInit, AfterViewInit, OnDestroy {
   private subject = new Subject();
+  private resubscribe = new BehaviorSubject<void>(null);
   @Input() id;
 
   clicked = false;
+  clickedOnConstrucor = false;
+  clickedOnInit = false;
+  clickedOnInitStatic = false;
+  clickedOnResuscribedConstructor = false;
+
+  constructorIsClickedFiveTimes = false;
+  oneConstructorStreamIsCompleted = false;
 
   @FromEvent('click')
   @ViewChild('button')
   click$: Observable<MouseEvent>;
 
+  @FromEvent('click')
+  @ViewChild('buttonConstructor')
+  clickFromConstructor$: Observable<MouseEvent>;
+
+  @FromEvent('click')
+  @ViewChild('buttonOnInit', { static: true })
+  clickFromOnInit$: Observable<MouseEvent>;
+
+  @FromEvent('click')
+  @ViewChild('buttonOnInit', { static: true })
+  clickFromOnInitStatic$: Observable<MouseEvent>;
+
+  clickFromConstructorResubscribed$ = this.resubscribe.pipe(switchMap(() => this.clickFromConstructor$));
+
+  constructor() {
+    this.clickFromConstructor$.pipe(takeUntil(this.subject)).subscribe((e) => {
+      this.clickedOnConstrucor = true;
+    });
+
+    this.clickFromConstructor$.pipe(take(2), takeUntil(this.subject)).subscribe({
+      complete: () => (this.oneConstructorStreamIsCompleted = true),
+    });
+
+    this.clickFromConstructor$.pipe(skip(4), takeUntil(this.subject)).subscribe((e) => {
+      this.constructorIsClickedFiveTimes = true;
+    });
+
+    this.clickFromConstructorResubscribed$.subscribe((e) => {
+      this.clickedOnResuscribedConstructor = true;
+    });
+
+    this.clickFromOnInit$.pipe(takeUntil(this.subject)).subscribe((e) => {
+      this.clickedOnInit = true;
+    });
+  }
+
+  ngOnInit() {
+    this.clickFromOnInitStatic$.pipe(takeUntil(this.subject)).subscribe((e) => {
+      this.clickedOnInitStatic = true;
+    });
+  }
+
   ngAfterViewInit() {
+    this.resubscribe.next();
+
     this.click$.pipe(takeUntil(this.subject)).subscribe((e) => {
       this.clicked = true;
     });
@@ -87,5 +143,76 @@ describe('FromEvent', () => {
     spectator.click('.toggle');
     expect(spectator.queryAll(ButtonComponent).length).toBe(0);
     expect(destroyed).toEqual([1, 2]);
+  });
+
+  it('should subscribe to observable on constructor', () => {
+    spectator.click('.toggle');
+
+    [1, 2].forEach((id) => {
+      spectator.query<HTMLButtonElement>(byText(`Constructor ${id}`)).click();
+    });
+
+    const buttons = spectator.queryAll(ButtonComponent);
+    buttons.forEach((btn) => {
+      expect(btn.clicked).toBeFalse();
+      expect(btn.clickedOnInitStatic).toBeFalse();
+      expect(btn.clickedOnInit).toBeFalse();
+
+      expect(btn.clickedOnConstrucor).toBeTrue();
+    });
+  });
+
+  it('should subscribe to observable on ngOnInit', () => {
+    spectator.click('.toggle');
+
+    [1, 2].forEach((id) => {
+      spectator.query<HTMLButtonElement>(byText(`OnInit ${id}`)).click();
+    });
+
+    const buttons = spectator.queryAll(ButtonComponent);
+    buttons.forEach((btn) => {
+      expect(btn.clicked).toBeFalse();
+      expect(btn.clickedOnConstrucor).toBeFalse();
+
+      expect(btn.clickedOnInit).toBeTrue();
+      expect(btn.clickedOnInitStatic).toBeTrue();
+    });
+  });
+
+  it('should allow re-subscription of an observable setted before ngAfterViewInit', () => {
+    spectator.click('.toggle');
+
+    [1, 2].forEach((id) => {
+      spectator.query<HTMLButtonElement>(byText(`Constructor ${id}`)).click();
+    });
+
+    const buttons = spectator.queryAll(ButtonComponent);
+    buttons.forEach((btn) => {
+      expect(btn.clicked).toBeFalse();
+
+      expect(btn.clickedOnResuscribedConstructor).toBeTrue();
+    });
+  });
+
+  it('should subscribe multiple times being independent streams', () => {
+    spectator.click('.toggle');
+
+    const [buttonOne] = spectator.queryAll(ButtonComponent);
+
+    expect(buttonOne.oneConstructorStreamIsCompleted).toBeFalse();
+    expect(buttonOne.constructorIsClickedFiveTimes).toBeFalse();
+
+    for (let i = 0; i < 2; i++) {
+      spectator.query<HTMLButtonElement>(byText(`Constructor 1`)).click();
+    }
+
+    expect(buttonOne.oneConstructorStreamIsCompleted).toBeTrue();
+    expect(buttonOne.constructorIsClickedFiveTimes).toBeFalse();
+
+    for (let i = 0; i < 3; i++) {
+      spectator.query<HTMLButtonElement>(byText(`Constructor 1`)).click();
+    }
+
+    expect(buttonOne.constructorIsClickedFiveTimes).toBeTrue();
   });
 });

--- a/projects/ngneat/from-event/src/lib/from-event.ts
+++ b/projects/ngneat/from-event/src/lib/from-event.ts
@@ -2,23 +2,25 @@ import { ElementRef } from '@angular/core';
 import { fromEvent, defer } from 'rxjs';
 
 import { initIfNeeded } from './init-if-needed';
+import { takeUntil } from 'rxjs/operators';
 
 export function FromEvent<K extends keyof DocumentEventMap>(event: K, eventOptions?: AddEventListenerOptions) {
   return function (target: any, propertyKey: string) {
     const eventToken = Symbol(propertyKey);
+    const destroyToken = Symbol(propertyKey);
 
     Object.defineProperty(target, propertyKey, {
       set(elementRef: ElementRef) {
         const event$ = fromEvent(elementRef.nativeElement, event, eventOptions);
 
         if (this[eventToken]) {
-          event$.subscribe(this[eventToken]);
+          event$.pipe(takeUntil(this[destroyToken])).subscribe(this[eventToken]);
         }
 
         this[eventToken] = event$;
       },
       get() {
-        initIfNeeded(this, eventToken);
+        initIfNeeded(this, eventToken, destroyToken);
 
         return defer(() => this[eventToken]);
       },

--- a/projects/ngneat/from-event/src/lib/from-event.ts
+++ b/projects/ngneat/from-event/src/lib/from-event.ts
@@ -1,16 +1,28 @@
 import { ElementRef } from '@angular/core';
-import { fromEvent } from 'rxjs';
+import { fromEvent, defer } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+import { initIfNeeded } from './init-if-needed';
 
 export function FromEvent<K extends keyof DocumentEventMap>(event: K, eventOptions?: AddEventListenerOptions) {
   return function (target: any, propertyKey: string) {
-    const event$ = Symbol();
+    const eventToken = Symbol(propertyKey);
+    const destroyToken = Symbol(propertyKey);
 
     Object.defineProperty(target, propertyKey, {
       set(elementRef: ElementRef) {
-        this[event$] = fromEvent(elementRef.nativeElement, event, eventOptions);
+        const event$ = fromEvent(elementRef.nativeElement, event, eventOptions);
+
+        if (this[eventToken]) {
+          event$.pipe(takeUntil(this[destroyToken])).subscribe(this[eventToken]);
+        }
+
+        this[eventToken] = event$;
       },
       get() {
-        return this[event$];
+        initIfNeeded(this, eventToken, destroyToken);
+
+        return defer(() => this[eventToken]);
       },
     });
   };

--- a/projects/ngneat/from-event/src/lib/from-event.ts
+++ b/projects/ngneat/from-event/src/lib/from-event.ts
@@ -1,26 +1,24 @@
 import { ElementRef } from '@angular/core';
 import { fromEvent, defer } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 
 import { initIfNeeded } from './init-if-needed';
 
 export function FromEvent<K extends keyof DocumentEventMap>(event: K, eventOptions?: AddEventListenerOptions) {
   return function (target: any, propertyKey: string) {
     const eventToken = Symbol(propertyKey);
-    const destroyToken = Symbol(propertyKey);
 
     Object.defineProperty(target, propertyKey, {
       set(elementRef: ElementRef) {
         const event$ = fromEvent(elementRef.nativeElement, event, eventOptions);
 
         if (this[eventToken]) {
-          event$.pipe(takeUntil(this[destroyToken])).subscribe(this[eventToken]);
+          event$.subscribe(this[eventToken]);
         }
 
         this[eventToken] = event$;
       },
       get() {
-        initIfNeeded(this, eventToken, destroyToken);
+        initIfNeeded(this, eventToken);
 
         return defer(() => this[eventToken]);
       },

--- a/projects/ngneat/from-event/src/lib/from-events.spec.ts
+++ b/projects/ngneat/from-event/src/lib/from-events.spec.ts
@@ -5,6 +5,7 @@ import { FromEvents } from '@ngneat/from-event';
 import { takeUntil } from 'rxjs/operators';
 
 let clicked = [];
+let clickedFromConstructorSubscription = [];
 
 @Component({
   selector: 'my-btn',
@@ -29,6 +30,13 @@ class HostComponent implements AfterViewInit, OnDestroy {
   @FromEvents('click')
   @ViewChildren(ButtonComponent, { read: ElementRef })
   clicks$: Observable<MouseEvent>;
+
+  constructor() {
+    this.clicks$.pipe(takeUntil(this.subject)).subscribe((event) => {
+      const id = (event.target as HTMLButtonElement).parentElement.getAttribute('id');
+      clickedFromConstructorSubscription.push(id);
+    });
+  }
 
   ngAfterViewInit() {
     this.clicks$.pipe(takeUntil(this.subject)).subscribe((event) => {
@@ -57,5 +65,6 @@ describe('FromEvents', () => {
     });
 
     expect(clicked).toEqual(['1', '2', '3']);
+    expect(clickedFromConstructorSubscription).toEqual(['1', '2', '3']);
   });
 });

--- a/projects/ngneat/from-event/src/lib/from-events.ts
+++ b/projects/ngneat/from-event/src/lib/from-events.ts
@@ -1,13 +1,12 @@
 import { ElementRef, QueryList } from '@angular/core';
 import { fromEvent, merge, defer } from 'rxjs';
-import { startWith, switchMap, takeUntil } from 'rxjs/operators';
+import { startWith, switchMap } from 'rxjs/operators';
 
 import { initIfNeeded } from './init-if-needed';
 
 export function FromEvents<K extends keyof DocumentEventMap>(event: K, eventOptions?: AddEventListenerOptions) {
   return function (target: any, propertyKey: string) {
     const eventToken = Symbol(propertyKey);
-    const destroyToken = Symbol(propertyKey);
 
     Object.defineProperty(target, propertyKey, {
       set(list: QueryList<ElementRef>) {
@@ -23,13 +22,13 @@ export function FromEvents<K extends keyof DocumentEventMap>(event: K, eventOpti
         );
 
         if (this[eventToken]) {
-          events$.pipe(takeUntil(this[destroyToken])).subscribe(this[eventToken]);
+          events$.subscribe(this[eventToken]);
         }
 
         this[eventToken] = events$;
       },
       get() {
-        initIfNeeded(this, eventToken, destroyToken);
+        initIfNeeded(this, eventToken);
 
         return defer(() => this[eventToken]);
       },

--- a/projects/ngneat/from-event/src/lib/init-if-needed.ts
+++ b/projects/ngneat/from-event/src/lib/init-if-needed.ts
@@ -1,14 +1,19 @@
 import { Subject } from 'rxjs';
 import { finalize, refCount, publish } from 'rxjs/operators';
 
-export function initIfNeeded(that: object, eventToken: symbol) {
+export function initIfNeeded(that: object, eventToken: symbol, destroyToken?: symbol) {
   if (!that[eventToken]) {
+    that[destroyToken] = new Subject();
     let event$ = new Subject();
 
     that[eventToken] = event$.pipe(
       finalize(() => {
         event$.complete();
         event$ = null;
+
+        that[destroyToken].next();
+        that[destroyToken].complete();
+        that[destroyToken] = null;
       }),
       publish(),
       refCount()

--- a/projects/ngneat/from-event/src/lib/init-if-needed.ts
+++ b/projects/ngneat/from-event/src/lib/init-if-needed.ts
@@ -1,20 +1,17 @@
 import { Subject } from 'rxjs';
-import { finalize } from 'rxjs/operators';
+import { finalize, refCount, publish } from 'rxjs/operators';
 
-export function initIfNeeded(that: object, eventToken: symbol, destroyToken: symbol) {
+export function initIfNeeded(that: object, eventToken: symbol) {
   if (!that[eventToken]) {
-    that[destroyToken] = new Subject();
     let event$ = new Subject();
 
     that[eventToken] = event$.pipe(
       finalize(() => {
-        that[destroyToken].next();
-        that[destroyToken].complete();
-        that[destroyToken] = null;
-
         event$.complete();
         event$ = null;
-      })
+      }),
+      publish(),
+      refCount()
     );
   }
 }

--- a/projects/ngneat/from-event/src/lib/init-if-needed.ts
+++ b/projects/ngneat/from-event/src/lib/init-if-needed.ts
@@ -1,0 +1,20 @@
+import { Subject } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+
+export function initIfNeeded(that: object, eventToken: symbol, destroyToken: symbol) {
+  if (!that[eventToken]) {
+    that[destroyToken] = new Subject();
+    let event$ = new Subject();
+
+    that[eventToken] = event$.pipe(
+      finalize(() => {
+        that[destroyToken].next();
+        that[destroyToken].complete();
+        that[destroyToken] = null;
+
+        event$.complete();
+        event$ = null;
+      })
+    );
+  }
+}

--- a/projects/ngneat/from-event/src/lib/init-if-needed.ts
+++ b/projects/ngneat/from-event/src/lib/init-if-needed.ts
@@ -1,5 +1,5 @@
 import { Subject } from 'rxjs';
-import { finalize, refCount, publish } from 'rxjs/operators';
+import { finalize, share } from 'rxjs/operators';
 
 export function initIfNeeded(that: object, eventToken: symbol, destroyToken?: symbol) {
   if (!that[eventToken]) {
@@ -15,8 +15,7 @@ export function initIfNeeded(that: object, eventToken: symbol, destroyToken?: sy
         that[destroyToken].complete();
         that[destroyToken] = null;
       }),
-      publish(),
-      refCount()
+      share()
     );
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,4 +9,8 @@
   </div>
 
   <app-view-children></app-view-children>
+
+  <div>
+    <app-counter></app-counter>
+  </div>
 </div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,9 +7,10 @@ import { TestComponent } from './test/test.component';
 import { CheckDirective } from './check.directive';
 import { ButtonComponent } from './button/button.component';
 import { ViewChildrenComponent } from './view-children/view-children.component';
+import { CounterComponent } from './counter/counter.component';
 
 @NgModule({
-  declarations: [AppComponent, TestComponent, CheckDirective, ButtonComponent, ViewChildrenComponent],
+  declarations: [AppComponent, TestComponent, CheckDirective, ButtonComponent, ViewChildrenComponent, CounterComponent],
   imports: [BrowserModule, AppRoutingModule],
   providers: [],
   bootstrap: [AppComponent],

--- a/src/app/counter/counter.component.html
+++ b/src/app/counter/counter.component.html
@@ -1,0 +1,4 @@
+<button #plus>+1</button>
+<button #minus>-1</button>
+<button #reset>Reset</button>
+{{ counter$ | async }}

--- a/src/app/counter/counter.component.ts
+++ b/src/app/counter/counter.component.ts
@@ -23,7 +23,7 @@ export class CounterComponent {
 
   count$ = merge(this.plus$.pipe(mapTo(1)), this.minus$.pipe(mapTo(-1))).pipe(
     startWith(0),
-    scan((count, addition) => count + addition)
+    scan((acc, curr) => acc + curr)
   );
 
   counter$ = this.reset$.pipe(

--- a/src/app/counter/counter.component.ts
+++ b/src/app/counter/counter.component.ts
@@ -1,0 +1,37 @@
+import { Component, ViewChild } from '@angular/core';
+import { FromEvent } from '@ngneat/from-event';
+import { Observable, merge } from 'rxjs';
+import { logDestroy } from '../observer';
+import { mapTo, scan, startWith, switchMap } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-counter',
+  templateUrl: './counter.component.html',
+})
+export class CounterComponent {
+  @FromEvent('click')
+  @ViewChild('plus')
+  plus$: Observable<MouseEvent>;
+
+  @FromEvent('click')
+  @ViewChild('minus')
+  minus$: Observable<MouseEvent>;
+
+  @FromEvent('click')
+  @ViewChild('reset')
+  reset$: Observable<MouseEvent>;
+
+  count$ = merge(this.plus$.pipe(mapTo(1)), this.minus$.pipe(mapTo(-1))).pipe(
+    startWith(0),
+    scan((count, addition) => count + addition)
+  );
+
+  counter$ = this.reset$.pipe(
+    startWith(null),
+    switchMap(() => this.count$)
+  );
+
+  ngOnDestroy() {
+    logDestroy('CounterComponent');
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Observables are setted in `AfterContentInit` hook.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
It allows to compose observables as component's properties and reduces boilerplate (no needed for `AfterContentInit` hook). For example, [`CounterComponent`](https://github.com/tonivj5/from-event/blob/feat/subject/src/app/counter/counter.component.ts).

The observable is ready to use from the beginning. If the content isn't initialized yet, it returns a subject, which will subscribe to the `fromEvent` once it's created. If the observable is resubscribed, the subject will be completed and removed, and the observable returned will be the `fromEvent` observable instead of the subject.

I haven't added tests, because I don't know if it looks ok for you or not :sweat_smile:. If you like this changes, I'll add them :+1:
## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
